### PR TITLE
Separated the update version from the file name and adapted the app to these new changes.

### DIFF
--- a/App/SDV/.idea/deploymentTargetSelector.xml
+++ b/App/SDV/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-04-22T12:53:15.381849600Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\pc\.android\avd\Pixel_8_Pro_API_34.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/App/SDV/app/build.gradle.kts
+++ b/App/SDV/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.android)
     kotlin("kapt")
     id("com.google.dagger.hilt.android")
+    kotlin("plugin.serialization") version "1.9.0"
 }
 
 val localProperties = Properties().apply {
@@ -95,6 +96,9 @@ dependencies {
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
+
+    // Kotlin Serialization
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 
     // ZHttp
     implementation("com.github.muhammadzkralla:ZHttp:2.8.9")

--- a/App/SDV/app/src/main/java/com/zkrallah/sdv/domain/models/UpdateResponse.kt
+++ b/App/SDV/app/src/main/java/com/zkrallah/sdv/domain/models/UpdateResponse.kt
@@ -1,0 +1,10 @@
+package com.zkrallah.sdv.domain.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UpdateResponse(
+    val file: String,
+    val version: String,
+    val checksum: String,
+)

--- a/App/SDV/app/src/main/java/com/zkrallah/sdv/presentation/home/HomeScreen.kt
+++ b/App/SDV/app/src/main/java/com/zkrallah/sdv/presentation/home/HomeScreen.kt
@@ -91,7 +91,7 @@ fun HomeScreen(homeViewModel: HomeViewModel = hiltViewModel()) {
     }
 
     Scaffold(contentWindowInsets = WindowInsets.systemBars, topBar = {
-        TopAppBar(title = { Text(text = "SDV") }, actions = {
+        TopAppBar(title = { Text(text = "Home") }, actions = {
             IconButton(onClick = { }) {
                 Icon(
                     imageVector = Icons.Default.Settings, contentDescription = "Settings"
@@ -195,7 +195,7 @@ fun ConnectionStatusCard(context: Context, imageLoader: ImageLoader) {
 
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Tesla Model 3",
+                    text = "My SDV",
                     style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold)
                 )
                 Text(

--- a/App/SDV/app/src/main/res/values/strings.xml
+++ b/App/SDV/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">SDV</string>
+    <string name="app_name">My SDV</string>
 </resources>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This OTA system is composed of four main components:
    A new update file is uploaded to the server using `curl`:
 
    ```bash
-   curl -F "file=@<update-file-version>.bin" https://<our-server-ip-address>:80/upload
+   curl -F "file=@<update-file-path>.bin" -F "version=<update-version>" >https://<our-server-ip-address>:5000/upload
    ```
 
 2. **Announcing the New Update**    
@@ -44,7 +44,7 @@ This OTA system is composed of four main components:
     Subscribed to `ota/response`, the ECU reacts by downloading the update using `curl`:
 
     ```bash
-    curl -O https://<our-server-ip-address>:5000/files/<update-file-version>.bin
+    curl -O https://<our-server-ip-address>:5000/files/<update-file-path>.bin
     ```
     During the download, the `ECU` publishes "updating" to the `ota/update_possible` topic as a retained message. This informs the app that the update is in progress.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This OTA system is composed of four main components:
     Subscribed to `ota/response`, the ECU reacts by downloading the update using `curl`:
 
     ```bash
-    curl -O https://<our-server-ip-address>:80/files/<update-file-version>.bin
+    curl -O https://<our-server-ip-address>:5000/files/<update-file-version>.bin
     ```
     During the download, the `ECU` publishes "updating" to the `ota/update_possible` topic as a retained message. This informs the app that the update is in progress.
 

--- a/Server/main.py
+++ b/Server/main.py
@@ -67,18 +67,19 @@ def upload():
     file_path = os.path.join(app.config["UPLOAD_FOLDER"], file.filename)
     file.save(file_path)
 
-    file_url = f"http://0.0.0.0/files/{file.filename}"
+    file_name = file.filename
     sha256 = hashlib.sha256()
     with open(file_path, "rb") as f:
         for block in iter(lambda: f.read(4096), b""):
             sha256.update(block)
 
     checksum = sha256.hexdigest()
-    payload = {"url": file_url, "checksum": checksum}
+    payload = {"file": file_name, "checksum": checksum}
 
     payload_str = json.dumps(payload)
     print(checksum)
-    publish.single("ota/update", payload_str, hostname="0.0.0.0", port=1883)
+    publish.single("ota/update_possible", payload_str, hostname="localhost", port=1883)
+    publish.single("ota/update", payload_str, hostname="localhost", port=1883)
 
     return "Upload success"
 
@@ -93,4 +94,4 @@ def download(filename):
 
 
 if __name__ == "__main__":
-    app.run(debug=True, host="0.0.0.0", port=80)
+    app.run(debug=True, host="0.0.0.0", port=5000)


### PR DESCRIPTION
fix(app): Show only the update version instead of all the update meta-data. <br>
feat(server): Separate the update version from the file name and send in with the payload to ota/udpate_possible topic as a retained message. <br>
docs: Update the two CURLs to address the new changes in both the server and the app.